### PR TITLE
Add visualize.sh for remote policy download + teleop

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+SSH_KEY_PATH="~/.ssh/oren-ssh-key"
+SSH_DIRECTORY="orengershony/pupper-simulations"
+DROIDS_IP_ADDRESS="tritondroids@132.249.64.152"

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ renderingEnv/
 
 outputs/*
 !outputs/.gitkeep
+locomotion/outputs/*
+!locomotion/outputs/.gitkeep
 locomotion/sim-outputs/media/*
 !locomotion/sim-outputs/media/.gitkeep
 locomotion/sim-outputs/policies/*

--- a/tests/test_visualize.sh
+++ b/tests/test_visualize.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Test suite for visualize.sh — no SSH connectivity required.
+# All tests use --dry-run or provoke early errors.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VISUALIZE="$PROJECT_DIR/visualize.sh"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+# ── Helpers ────────────────────────────────────────────────────────────
+run_test() {
+  local name="$1"
+  TOTAL=$((TOTAL + 1))
+  echo -n "  [$TOTAL] $name ... "
+}
+
+pass() {
+  PASS=$((PASS + 1))
+  echo "PASS"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  echo "FAIL"
+  [ -n "${1:-}" ] && echo "       -> $1"
+}
+
+# Create a temporary .env for tests that need one
+make_test_env() {
+  cat > "$PROJECT_DIR/.env.test" <<'EOF'
+SSH_KEY_PATH="/tmp/test-ssh-key-visualize"
+SSH_DIRECTORY="testuser/test-project"
+DROIDS_IP_ADDRESS="testuser@192.168.1.100"
+EOF
+}
+
+cleanup() {
+  rm -f "$PROJECT_DIR/.env.test"
+  rm -f /tmp/test-ssh-key-visualize
+}
+trap cleanup EXIT
+
+# ── Tests ──────────────────────────────────────────────────────────────
+echo ""
+echo "Running visualize.sh tests..."
+echo ""
+
+# 1. Missing .env → clear error
+run_test "Missing .env produces error"
+# Run with a non-existent .env by temporarily hiding the real one
+output=$(cd /tmp && bash "$VISUALIZE" 2>&1 || true)
+if echo "$output" | grep -q "Error: .env file not found"; then
+  pass
+else
+  fail "Expected '.env file not found' error, got: $output"
+fi
+
+# 2. Missing required env var → names the missing variable
+run_test "Missing required env var names the variable"
+cat > "$PROJECT_DIR/.env.test" <<'EOF'
+SSH_KEY_PATH="/tmp/test-ssh-key-visualize"
+SSH_DIRECTORY=""
+DROIDS_IP_ADDRESS="testuser@192.168.1.100"
+EOF
+# Temporarily swap .env
+mv_env=false
+if [ -f "$PROJECT_DIR/.env" ]; then
+  mv "$PROJECT_DIR/.env" "$PROJECT_DIR/.env.bak"
+  mv_env=true
+fi
+cp "$PROJECT_DIR/.env.test" "$PROJECT_DIR/.env"
+output=$(bash "$VISUALIZE" 2>&1 || true)
+if echo "$output" | grep -q "SSH_DIRECTORY"; then
+  pass
+else
+  fail "Expected SSH_DIRECTORY in error, got: $output"
+fi
+rm -f "$PROJECT_DIR/.env"
+if [ "$mv_env" = true ]; then
+  mv "$PROJECT_DIR/.env.bak" "$PROJECT_DIR/.env"
+fi
+
+# 3. Invalid SSH key path → error before scp
+run_test "Invalid SSH key path produces error"
+make_test_env
+if [ -f "$PROJECT_DIR/.env" ]; then
+  mv "$PROJECT_DIR/.env" "$PROJECT_DIR/.env.bak"
+  mv_env=true
+else
+  mv_env=false
+fi
+cp "$PROJECT_DIR/.env.test" "$PROJECT_DIR/.env"
+output=$(bash "$VISUALIZE" 2>&1 || true)
+if echo "$output" | grep -q "Error: SSH key not found"; then
+  pass
+else
+  fail "Expected 'SSH key not found' error, got: $output"
+fi
+rm -f "$PROJECT_DIR/.env"
+if [ "$mv_env" = true ]; then
+  mv "$PROJECT_DIR/.env.bak" "$PROJECT_DIR/.env"
+fi
+
+# 4. Unknown flag → usage message
+run_test "Unknown flag shows usage"
+make_test_env
+if [ -f "$PROJECT_DIR/.env" ]; then
+  mv "$PROJECT_DIR/.env" "$PROJECT_DIR/.env.bak"
+  mv_env=true
+else
+  mv_env=false
+fi
+cp "$PROJECT_DIR/.env.test" "$PROJECT_DIR/.env"
+output=$(bash "$VISUALIZE" --bogus-flag 2>&1 || true)
+if echo "$output" | grep -q "Unknown flag" && echo "$output" | grep -q "Usage"; then
+  pass
+else
+  fail "Expected usage message with unknown flag error, got: $output"
+fi
+rm -f "$PROJECT_DIR/.env"
+if [ "$mv_env" = true ]; then
+  mv "$PROJECT_DIR/.env.bak" "$PROJECT_DIR/.env"
+fi
+
+# 5. --dry-run prints correct scp command
+run_test "--dry-run prints scp command with correct remote path"
+make_test_env
+touch /tmp/test-ssh-key-visualize
+if [ -f "$PROJECT_DIR/.env" ]; then
+  mv "$PROJECT_DIR/.env" "$PROJECT_DIR/.env.bak"
+  mv_env=true
+else
+  mv_env=false
+fi
+cp "$PROJECT_DIR/.env.test" "$PROJECT_DIR/.env"
+output=$(bash "$VISUALIZE" --dry-run 2>&1)
+if echo "$output" | grep -q "scp.*testuser@192.168.1.100:testuser/test-project/locomotion/outputs/policy.onnx"; then
+  pass
+else
+  fail "Expected scp command with correct remote path, got: $output"
+fi
+rm -f "$PROJECT_DIR/.env"
+if [ "$mv_env" = true ]; then
+  mv "$PROJECT_DIR/.env.bak" "$PROJECT_DIR/.env"
+fi
+
+# 6. --dry-run --video prints both policy and video scp commands
+run_test "--dry-run --video prints both scp commands"
+make_test_env
+touch /tmp/test-ssh-key-visualize
+if [ -f "$PROJECT_DIR/.env" ]; then
+  mv "$PROJECT_DIR/.env" "$PROJECT_DIR/.env.bak"
+  mv_env=true
+else
+  mv_env=false
+fi
+cp "$PROJECT_DIR/.env.test" "$PROJECT_DIR/.env"
+output=$(bash "$VISUALIZE" --dry-run --video 2>&1)
+policy_scp=$(echo "$output" | grep -c "scp.*policy.onnx" || true)
+video_scp=$(echo "$output" | grep -c "scp.*latest_video.mp4" || true)
+if [ "$policy_scp" -ge 1 ] && [ "$video_scp" -ge 1 ]; then
+  pass
+else
+  fail "Expected both policy and video scp commands, got: $output"
+fi
+rm -f "$PROJECT_DIR/.env"
+if [ "$mv_env" = true ]; then
+  mv "$PROJECT_DIR/.env.bak" "$PROJECT_DIR/.env"
+fi
+
+# 7. --dry-run --download-only does not print mjpython command
+run_test "--dry-run --download-only omits mjpython"
+make_test_env
+touch /tmp/test-ssh-key-visualize
+if [ -f "$PROJECT_DIR/.env" ]; then
+  mv "$PROJECT_DIR/.env" "$PROJECT_DIR/.env.bak"
+  mv_env=true
+else
+  mv_env=false
+fi
+cp "$PROJECT_DIR/.env.test" "$PROJECT_DIR/.env"
+output=$(bash "$VISUALIZE" --dry-run --download-only 2>&1)
+if echo "$output" | grep -q "mjpython"; then
+  fail "mjpython should not appear with --download-only, got: $output"
+else
+  pass
+fi
+rm -f "$PROJECT_DIR/.env"
+if [ "$mv_env" = true ]; then
+  mv "$PROJECT_DIR/.env.bak" "$PROJECT_DIR/.env"
+fi
+
+# 8. Local output directory creation works
+run_test "Creates locomotion/outputs/ directory"
+make_test_env
+touch /tmp/test-ssh-key-visualize
+if [ -f "$PROJECT_DIR/.env" ]; then
+  mv "$PROJECT_DIR/.env" "$PROJECT_DIR/.env.bak"
+  mv_env=true
+else
+  mv_env=false
+fi
+cp "$PROJECT_DIR/.env.test" "$PROJECT_DIR/.env"
+# Remove the directory if it exists (but preserve .gitkeep)
+bash "$VISUALIZE" --dry-run > /dev/null 2>&1
+if [ -d "$PROJECT_DIR/locomotion/outputs" ]; then
+  pass
+else
+  fail "locomotion/outputs/ directory was not created"
+fi
+rm -f "$PROJECT_DIR/.env"
+if [ "$mv_env" = true ]; then
+  mv "$PROJECT_DIR/.env.bak" "$PROJECT_DIR/.env"
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS/$TOTAL passed, $FAIL failed"
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi

--- a/visualize.sh
+++ b/visualize.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Download trained policy from remote SSH node and launch MuJoCo teleop.
+#
+# Usage:
+#   ./visualize.sh               # download policy + launch teleop
+#   ./visualize.sh --dry-run      # print commands without executing
+#   ./visualize.sh --download-only # download only, no teleop
+#   ./visualize.sh --video        # also download training video
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/.env"
+
+# ── Flags ──────────────────────────────────────────────────────────────
+DRY_RUN=false
+DOWNLOAD_ONLY=false
+DOWNLOAD_VIDEO=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)       DRY_RUN=true ;;
+    --download-only) DOWNLOAD_ONLY=true ;;
+    --video)         DOWNLOAD_VIDEO=true ;;
+    *)
+      echo "Error: Unknown flag '$arg'"
+      echo ""
+      echo "Usage: ./visualize.sh [--dry-run] [--download-only] [--video]"
+      echo "  --dry-run        Print commands without executing"
+      echo "  --download-only  Download policy but don't launch teleop"
+      echo "  --video          Also download training video"
+      exit 1
+      ;;
+  esac
+done
+
+# ── Load .env ──────────────────────────────────────────────────────────
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Error: .env file not found at $ENV_FILE"
+  echo "Copy .env.example to .env and fill in your SSH credentials."
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+source "$ENV_FILE"
+
+# ── Validate required variables ────────────────────────────────────────
+missing=()
+[ -z "${SSH_KEY_PATH:-}" ]      && missing+=("SSH_KEY_PATH")
+[ -z "${SSH_DIRECTORY:-}" ]     && missing+=("SSH_DIRECTORY")
+[ -z "${DROIDS_IP_ADDRESS:-}" ] && missing+=("DROIDS_IP_ADDRESS")
+
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "Error: Missing required environment variable(s): ${missing[*]}"
+  exit 1
+fi
+
+# Expand ~ in SSH_KEY_PATH
+SSH_KEY_PATH="${SSH_KEY_PATH/#\~/$HOME}"
+
+# ── Validate SSH key ──────────────────────────────────────────────────
+if [ "$DRY_RUN" = false ] && [ ! -f "$SSH_KEY_PATH" ]; then
+  echo "Error: SSH key not found at $SSH_KEY_PATH"
+  exit 1
+fi
+
+# ── Paths ─────────────────────────────────────────────────────────────
+REMOTE_POLICY="$SSH_DIRECTORY/locomotion/outputs/policy.onnx"
+LOCAL_POLICY="$SCRIPT_DIR/locomotion/outputs/policy.onnx"
+
+REMOTE_VIDEO="$SSH_DIRECTORY/locomotion/outputs/videos/latest_video.mp4"
+LOCAL_VIDEO="$SCRIPT_DIR/locomotion/sim-outputs/media/latest_video.mp4"
+
+# ── Ensure local directories exist ─────────────────────────────────────
+mkdir -p "$SCRIPT_DIR/locomotion/outputs"
+if [ "$DOWNLOAD_VIDEO" = true ]; then
+  mkdir -p "$SCRIPT_DIR/locomotion/sim-outputs/media"
+fi
+
+# ── Download policy ────────────────────────────────────────────────────
+SCP_CMD="scp -i $SSH_KEY_PATH $DROIDS_IP_ADDRESS:$REMOTE_POLICY $LOCAL_POLICY"
+
+if [ "$DRY_RUN" = true ]; then
+  echo "[dry-run] $SCP_CMD"
+else
+  echo "Downloading policy..."
+  $SCP_CMD
+  echo "Policy saved to $LOCAL_POLICY"
+fi
+
+# ── Download video (optional) ─────────────────────────────────────────
+if [ "$DOWNLOAD_VIDEO" = true ]; then
+  SCP_VIDEO_CMD="scp -i $SSH_KEY_PATH $DROIDS_IP_ADDRESS:$REMOTE_VIDEO $LOCAL_VIDEO"
+
+  if [ "$DRY_RUN" = true ]; then
+    echo "[dry-run] $SCP_VIDEO_CMD"
+  else
+    echo "Downloading video..."
+    $SCP_VIDEO_CMD
+    echo "Video saved to $LOCAL_VIDEO"
+  fi
+fi
+
+# ── Launch teleop ─────────────────────────────────────────────────────
+if [ "$DOWNLOAD_ONLY" = true ]; then
+  echo "Download complete (--download-only). Skipping teleop."
+  exit 0
+fi
+
+TELEOP_CMD="mjpython $SCRIPT_DIR/teleop_locomotion.py --policy $LOCAL_POLICY"
+
+if [ "$DRY_RUN" = true ]; then
+  echo "[dry-run] $TELEOP_CMD"
+else
+  echo "Launching teleop..."
+  exec $TELEOP_CMD
+fi


### PR DESCRIPTION
## Summary
- Add `visualize.sh` — single script to `scp` trained policy from remote SSH node and launch `mjpython` teleop for visualization
- Replaces old `train.sh`/`view-results.sh` workflow (git deploy + HTTP server + port forwarding) with simple `scp` + `mjpython`
- Supports `--dry-run`, `--download-only`, and `--video` flags
- Add `.env.example` with minimal 3-variable SSH config
- Add test suite (`tests/test_visualize.sh`) with 8 tests, all passing without SSH connectivity

## Test plan
- [x] `tests/test_visualize.sh` — 8/8 tests pass (missing .env, missing env var, invalid SSH key, unknown flag, dry-run scp output, dry-run video, download-only, directory creation)
- [ ] End-to-end: `./visualize.sh` downloads policy and launches teleop (requires SSH + remote policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)