### PR TITLE
Add automatic video recording after training

### DIFF
--- a/locomotion/video_recorder.py
+++ b/locomotion/video_recorder.py
@@ -1,0 +1,139 @@
+"""Video recording utility for trained Brax policies.
+
+Records a short rollout of a trained policy and saves it as MP4.
+Follows the same rendering approach as legacy/visualize.py.
+"""
+
+import numpy as np
+import jax
+import jax.numpy as jp
+import mujoco
+
+
+def generate_rollout(env, inference_fn, num_steps=250, seed=0):
+    """Run the trained policy in the environment and collect pipeline states.
+
+    Args:
+        env: Brax environment instance.
+        inference_fn: Policy function taking (obs, rng_key) -> (action, extras).
+        num_steps: Number of environment steps to simulate.
+        seed: Random seed for reproducibility.
+
+    Returns:
+        List of pipeline_state objects (length num_steps + 1, including reset).
+    """
+    jit_reset = jax.jit(env.reset)
+    jit_step = jax.jit(env.step)
+
+    rng = jax.random.PRNGKey(seed)
+    state = jit_reset(rng)
+    rollout = [state.pipeline_state]
+
+    for _ in range(num_steps):
+        rng, key_sample = jax.random.split(rng)
+        action, _ = inference_fn(state.obs, key_sample)
+        state = jit_step(state, action)
+        rollout.append(state.pipeline_state)
+
+    return rollout
+
+
+def render_frames(env, rollout, width=640, height=480):
+    """Render each pipeline state to an RGB frame using MuJoCo.
+
+    Args:
+        env: Brax environment (must have env.sys.mj_model).
+        rollout: List of pipeline_state objects.
+        width: Frame width in pixels.
+        height: Frame height in pixels.
+
+    Returns:
+        List of numpy arrays with shape (height, width, 3) dtype uint8.
+    """
+    mj_model = env.sys.mj_model
+    renderer = mujoco.Renderer(mj_model, height=height, width=width)
+
+    frames = []
+    for pipeline_state in rollout:
+        mj_data = mujoco.MjData(mj_model)
+        mj_data.qpos[:] = np.array(pipeline_state.q)
+        mj_data.qvel[:] = np.array(pipeline_state.qd)
+        mujoco.mj_forward(mj_model, mj_data)
+
+        renderer.update_scene(mj_data)
+        pixels = renderer.render()
+        frames.append(pixels)
+
+    renderer.close()
+    return frames
+
+
+def save_video_mp4(frames, output_path, fps=50):
+    """Encode RGB frames to an MP4 file using OpenCV.
+
+    Args:
+        frames: List of RGB numpy arrays (H, W, 3).
+        output_path: Path to write the .mp4 file.
+        fps: Frames per second.
+
+    Raises:
+        ValueError: If frames list is empty.
+        ImportError: If opencv-python-headless is not installed.
+    """
+    if not frames:
+        raise ValueError("No frames to write")
+
+    try:
+        import cv2
+    except ImportError:
+        raise ImportError(
+            "opencv-python-headless is required for video recording. "
+            "Install with: pip install opencv-python-headless"
+        )
+
+    from pathlib import Path
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+
+    height, width, _ = frames[0].shape
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    out = cv2.VideoWriter(str(output_path), fourcc, fps, (width, height))
+
+    if not out.isOpened():
+        raise RuntimeError(f"Failed to open video writer for {output_path}")
+
+    for frame in frames:
+        frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+        out.write(frame_bgr)
+
+    out.release()
+
+
+def record_video(env, make_policy, params, output_path,
+                 num_steps=250, seed=0, width=640, height=480, fps=50):
+    """High-level entry point: rollout + render + save.
+
+    Args:
+        env: Brax environment instance.
+        make_policy: Function from ppo.train() that creates an inference fn.
+            Called as make_policy(params, deterministic=True).
+        params: Trained policy parameters (normalizer, policy, value).
+        output_path: Where to save the MP4 file.
+        num_steps: Number of simulation steps (default 250 = 5s at 50Hz).
+        seed: Random seed for rollout.
+        width: Video frame width.
+        height: Video frame height.
+        fps: Video frames per second.
+    """
+    print("Recording video...")
+
+    inference_fn = make_policy(params, deterministic=True)
+    print(f"  Generating rollout ({num_steps} steps)...")
+    rollout = generate_rollout(env, inference_fn, num_steps=num_steps, seed=seed)
+
+    print(f"  Rendering {len(rollout)} frames at {width}x{height}...")
+    frames = render_frames(env, rollout, width=width, height=height)
+
+    print(f"  Saving video to {output_path}...")
+    save_video_mp4(frames, output_path, fps=fps)
+
+    print(f"  Video saved ({len(frames)} frames)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "brax==0.13.0",
     "onnx>=1.15.0",
     "onnxruntime>=1.16.0",
+    "opencv-python-headless>=4.8.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_video_recorder.py
+++ b/tests/test_video_recorder.py
@@ -1,0 +1,122 @@
+"""Tests for locomotion/video_recorder.py."""
+
+import os
+import platform
+import sys
+import numpy as np
+import pytest
+
+# Add locomotion to path so imports work the same as when running from locomotion/
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "locomotion"))
+
+# Use EGL on Linux (remote training node), GLFW on macOS
+if platform.system() == "Darwin":
+    os.environ.setdefault("MUJOCO_GL", "glfw")
+else:
+    os.environ.setdefault("MUJOCO_GL", "egl")
+
+import jax
+import jax.numpy as jp
+from brax import envs
+from bittle_env import BittleEnv
+from video_recorder import generate_rollout, render_frames, save_video_mp4, record_video
+
+
+XML_PATH = os.path.join(os.path.dirname(__file__), "..", "locomotion", "bittle_adapted_scene.xml")
+
+
+@pytest.fixture(scope="module")
+def env():
+    """Create a Brax BittleEnv for tests (shared across module)."""
+    envs.register_environment("bittle", BittleEnv)
+    return envs.get_environment("bittle", xml_path=XML_PATH)
+
+
+@pytest.fixture(scope="module")
+def dummy_inference_fn():
+    """Return a simple zero-action inference function."""
+    def fn(obs, rng_key):
+        return jp.zeros(9), {}
+    return fn
+
+
+# ── generate_rollout tests ─────────────────────────────────────────────
+
+class TestGenerateRollout:
+    def test_correct_state_count(self, env, dummy_inference_fn):
+        num_steps = 5
+        rollout = generate_rollout(env, dummy_inference_fn, num_steps=num_steps, seed=0)
+        # num_steps + 1 because we include the reset state
+        assert len(rollout) == num_steps + 1
+
+    def test_states_have_q_and_qd(self, env, dummy_inference_fn):
+        rollout = generate_rollout(env, dummy_inference_fn, num_steps=3, seed=0)
+        for state in rollout:
+            q = np.array(state.q)
+            qd = np.array(state.qd)
+            assert q.ndim == 1 and q.shape[0] > 0
+            assert qd.ndim == 1 and qd.shape[0] > 0
+
+    def test_deterministic_with_same_seed(self, env, dummy_inference_fn):
+        rollout_a = generate_rollout(env, dummy_inference_fn, num_steps=5, seed=42)
+        rollout_b = generate_rollout(env, dummy_inference_fn, num_steps=5, seed=42)
+        for sa, sb in zip(rollout_a, rollout_b):
+            np.testing.assert_array_equal(np.array(sa.q), np.array(sb.q))
+
+
+# ── save_video_mp4 tests ──────────────────────────────────────────────
+
+class TestSaveVideoMp4:
+    def test_creates_file(self, tmp_path):
+        frames = [np.zeros((48, 64, 3), dtype=np.uint8) for _ in range(10)]
+        out = tmp_path / "test.mp4"
+        save_video_mp4(frames, str(out), fps=10)
+        assert out.exists()
+        assert out.stat().st_size > 0
+
+    def test_creates_parent_dirs(self, tmp_path):
+        out = tmp_path / "a" / "b" / "test.mp4"
+        frames = [np.zeros((48, 64, 3), dtype=np.uint8) for _ in range(5)]
+        save_video_mp4(frames, str(out), fps=10)
+        assert out.exists()
+
+    def test_raises_on_empty_frames(self, tmp_path):
+        with pytest.raises(ValueError, match="No frames"):
+            save_video_mp4([], str(tmp_path / "empty.mp4"))
+
+
+# ── render_frames tests ───────────────────────────────────────────────
+
+class TestRenderFrames:
+    def test_correct_shape_and_dtype(self, env, dummy_inference_fn):
+        rollout = generate_rollout(env, dummy_inference_fn, num_steps=3, seed=0)
+        width, height = 64, 48
+        frames = render_frames(env, rollout, width=width, height=height)
+        assert len(frames) == len(rollout)
+        for f in frames:
+            assert f.shape == (height, width, 3)
+            assert f.dtype == np.uint8
+
+
+# ── record_video end-to-end test ──────────────────────────────────────
+
+class TestRecordVideo:
+    def test_produces_valid_mp4(self, env, tmp_path):
+        def make_policy(params, deterministic=False):
+            def policy(obs, rng_key):
+                return jp.zeros(9), {}
+            return policy
+
+        out = tmp_path / "video.mp4"
+        record_video(
+            env,
+            make_policy,
+            params=None,
+            output_path=str(out),
+            num_steps=5,
+            width=64,
+            height=48,
+            fps=10,
+        )
+        assert out.exists()
+        assert out.stat().st_size > 0


### PR DESCRIPTION
## Summary
- Adds `locomotion/video_recorder.py` module that records a 5-second rollout video of the trained policy after training completes
- Modifies `train.py` to capture `make_policy` from `ppo.train()` and call video recording after ONNX export (non-fatal on failure)
- Adds `--no-video` and `--video-output` CLI flags to `train.py`
- Adds `opencv-python-headless>=4.8.0` dependency to `pyproject.toml`
- Adds `tests/test_video_recorder.py` with 8 pytest tests covering all video recorder functions

## Test plan
- [x] `python -m pytest tests/test_video_recorder.py -v` — 8/8 passed
- [x] `bash tests/test_visualize.sh` — 8/8 passed (existing tests unaffected)
- [ ] `cd locomotion && python train.py --test` — verify video appears at `locomotion/outputs/videos/latest_video.mp4`
- [ ] `cd locomotion && python train.py --test --no-video` — verify video is skipped

Generated with [Claude Code](https://claude.com/claude-code)