### PR TITLE
Add pytest testing suite (29 tests)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.testing.pytestEnabled": true,
+    "python.testing.pytestArgs": ["tests", "-v"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dev = [
     "jupyter",
     "notebook",
     "ipython",
+    "pytest>=8.0",
+    "pytest-mock>=3.12",
 ]
 
 [project.urls]
@@ -42,3 +44,7 @@ packages = ["locomotion"]
 
 [tool.setuptools.package-data]
 "*" = ["*.xml", "*.mjcf"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,58 @@
+"""Shared fixtures and path setup for the test suite."""
+
+import os
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+# Force JAX to use CPU (no GPU required for tests)
+os.environ["JAX_PLATFORM_NAME"] = "cpu"
+
+# Ensure MUJOCO_GL is valid for this platform before any module sets it to "egl".
+# train.py sets MUJOCO_GL=egl at import time, which is invalid on macOS.
+os.environ.pop("MUJOCO_GL", None)
+
+# Pre-import mujoco so it caches with a valid GL setting.
+# Later imports (even after train.py sets MUJOCO_GL=egl) use the cached module.
+import mujoco  # noqa: E402,F401
+
+# Add project paths so bare imports in locomotion/ work (e.g. train.py imports bittle_env)
+_project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_locomotion_dir = os.path.join(_project_root, "locomotion")
+for _p in (_project_root, _locomotion_dir):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+@pytest.fixture
+def fake_policy_params():
+    """Brax PPO params tuple with correct shapes for ONNX export.
+
+    Network: 510 -> 256 -> 256 -> 256 -> 256 -> 18  (5 hidden layers)
+    Output 18 = 9 action means + 9 log_stds, sliced to first 9.
+    """
+    normalizer = SimpleNamespace(
+        mean=np.zeros(510, dtype=np.float32),
+        std=np.ones(510, dtype=np.float32) * 2.0,
+    )
+
+    layer_sizes = [
+        (510, 256),   # hidden_0
+        (256, 256),   # hidden_1
+        (256, 256),   # hidden_2
+        (256, 256),   # hidden_3
+        (256, 18),    # hidden_4 (output: 9 means + 9 log_stds)
+    ]
+    policy_params = {"params": {}}
+    rng = np.random.RandomState(42)
+    for i, (fan_in, fan_out) in enumerate(layer_sizes):
+        policy_params["params"][f"hidden_{i}"] = {
+            "kernel": rng.randn(fan_in, fan_out).astype(np.float32) * 0.01,
+            "bias": np.zeros(fan_out, dtype=np.float32),
+        }
+
+    value_params = None  # not used in export
+
+    return (normalizer, policy_params, value_params)

--- a/tests/test_bittle_env.py
+++ b/tests/test_bittle_env.py
@@ -1,0 +1,343 @@
+"""Tests for locomotion/bittle_env.py (19 tests, 1 per function/method)."""
+
+from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jp
+import numpy as np
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+OBS_SIZE = 34  # 1 + 3 + 3 + 9 + 9 + 9
+NU = 9
+
+DEFAULT_POSE = jp.array([
+    -0.6908, 1.9782, 0.7222, 1.9468, -0.596904,
+    -0.6908, 1.9782, 0.7222, 1.9468,
+])
+
+
+def _make_fake_sys():
+    """Return a lightweight fake sys object that satisfies BittleEnv.__init__."""
+    sys = MagicMock()
+    sys.nq = 16  # 7 freejoint + 9 actuated
+    sys.nv = 15  # 6 freejoint + 9 actuated
+    sys.nu = 9
+    sys.opt.timestep = 0.004
+    sys.dof_damping = jp.zeros(15)
+    sys.mj_model = MagicMock()
+    # tree_replace returns a copy with modifications
+    sys.tree_replace = lambda d: sys
+    sys.replace = lambda **kw: sys
+    return sys
+
+
+class _FakePipelineState(SimpleNamespace):
+    """SimpleNamespace with a .replace() method mimicking brax State."""
+
+    def replace(self, **kwargs):
+        import copy
+        new = copy.copy(self)
+        for k, v in kwargs.items():
+            setattr(new, k, v)
+        return new
+
+
+def _make_pipeline_state():
+    """Return a fake pipeline_state for reward / obs testing."""
+    nq, nv = 16, 15
+    ps = _FakePipelineState(
+        q=jp.zeros(nq),
+        qd=jp.zeros(nv),
+        x=SimpleNamespace(
+            pos=jp.array([[0.0, 0.0, 0.075]] * 5),   # 5 bodies
+            rot=jp.array([[1.0, 0.0, 0.0, 0.0]] * 5),
+        ),
+        xd=SimpleNamespace(
+            vel=jp.zeros((5, 3)),
+            ang=jp.zeros((5, 3)),
+        ),
+        xpos=jp.array([[0.0, 0.0, 0.075]] * 5),
+        qfrc_actuator=jp.zeros(nv),
+    )
+    # Set joint positions to default pose
+    ps.q = ps.q.at[7:].set(DEFAULT_POSE)
+    return ps
+
+
+def _build_env():
+    """Instantiate BittleEnv with all heavy deps mocked out."""
+    with patch("bittle_env.mjcf.load") as mock_load, \
+         patch("bittle_env.mujoco.mj_name2id") as mock_name2id, \
+         patch("bittle_env.PipelineEnv.__init__", return_value=None):
+
+        mock_load.return_value = _make_fake_sys()
+        # base=1, four legs=2,3,4,5
+        mock_name2id.side_effect = lambda *a, **kw: {
+            "base": 1,
+            "servos_rf_1": 2,
+            "servos_rr_1": 3,
+            "servos_lf_1": 4,
+            "servos_lr_1": 5,
+        }.get(a[-1], 0)
+
+        from bittle_env import BittleEnv
+        env = BittleEnv(xml_path="dummy.xml")
+        # Manually set attributes that PipelineEnv.__init__ would set
+        env.sys = _make_fake_sys()
+        # dt is a read-only property: dt = sys.opt.timestep * _n_frames
+        # 0.004 * 5 = 0.02
+        env._n_frames = 5
+        return env
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetConfig:
+    def test_get_config(self):
+        from bittle_env import get_config
+        cfg = get_config()
+        scales = cfg.rewards.scales
+        expected_keys = {
+            "tracking_lin_vel", "tracking_ang_vel",
+            "lin_vel_z", "ang_vel_xy", "orientation",
+            "torques", "action_rate", "joint_acc",
+            "stand_still", "termination",
+            "feet_air_time", "foot_slip", "energy",
+        }
+        assert set(scales.keys()) == expected_keys
+        assert cfg.rewards.tracking_sigma == 0.25
+
+
+class TestBittleEnvInit:
+    def test_init(self):
+        env = _build_env()
+        assert env._action_scale == 0.5
+        assert env._obs_noise == 0.05
+        assert env._default_pose.shape == (9,)
+        assert env._q_joint_start == 7
+        assert env._qd_joint_start == 6
+        assert len(env._lower_leg_body_id) == 4
+
+
+class TestSampleCommand:
+    def test_sample_command(self):
+        env = _build_env()
+        rng = jax.random.PRNGKey(0)
+        cmd = env.sample_command(rng)
+        assert cmd.shape == (3,)
+        assert -0.3 <= float(cmd[0]) <= 0.6
+        assert -0.3 <= float(cmd[1]) <= 0.3
+        assert -0.5 <= float(cmd[2]) <= 0.5
+
+
+class TestReset:
+    def test_reset(self):
+        env = _build_env()
+        rng = jax.random.PRNGKey(1)
+        ps = _make_pipeline_state()
+        with patch.object(env, "pipeline_init", return_value=ps):
+            state = env.reset(rng)
+        assert state.obs.shape == (510,)
+        assert float(state.reward) == 0.0
+        assert float(state.done) == 0.0
+
+
+class TestStep:
+    def test_step(self):
+        env = _build_env()
+        rng = jax.random.PRNGKey(2)
+        ps = _make_pipeline_state()
+        with patch.object(env, "pipeline_init", return_value=ps):
+            state = env.reset(rng)
+        ps2 = _make_pipeline_state()
+        with patch.object(env, "pipeline_step", return_value=ps2):
+            action = jp.zeros(9)
+            new_state = env.step(state, action)
+        assert new_state.obs.shape == (510,)
+        # last_act should be updated to the action we passed in
+        assert jp.allclose(new_state.info["last_act"], action)
+        # step ran (reward is a scalar, pipeline_state was consumed)
+        assert new_state.reward.shape == ()
+
+
+class TestGetObs:
+    def test_get_obs(self):
+        env = _build_env()
+        ps = _make_pipeline_state()
+        rng = jax.random.PRNGKey(3)
+        state_info = {
+            "rng": rng,
+            "last_act": jp.zeros(NU),
+            "command": jp.array([0.1, 0.0, 0.0]),
+        }
+        obs_history = jp.zeros(15 * OBS_SIZE)
+        obs = env._get_obs(ps, state_info, obs_history)
+        assert obs.shape == (510,)
+        # After one call, first OBS_SIZE elements should be non-trivially set
+        # (at least gravity component is nonzero)
+        assert not jp.allclose(obs[:OBS_SIZE], jp.zeros(OBS_SIZE))
+
+
+# ---------------------------------------------------------------------------
+# Reward function tests
+# ---------------------------------------------------------------------------
+
+class TestRewardLinVelZ:
+    def test_reward_lin_vel_z(self):
+        env = _build_env()
+        env._base_body_id = 1
+        xd_zero = SimpleNamespace(vel=jp.zeros((5, 3)), ang=jp.zeros((5, 3)))
+        assert float(env._reward_lin_vel_z(xd_zero)) == 0.0
+        xd_nonzero = SimpleNamespace(
+            vel=jp.zeros((5, 3)).at[1, 2].set(2.0), ang=jp.zeros((5, 3))
+        )
+        assert float(env._reward_lin_vel_z(xd_nonzero)) > 0.0
+
+
+class TestRewardAngVelXY:
+    def test_reward_ang_vel_xy(self):
+        env = _build_env()
+        env._base_body_id = 1
+        xd_zero = SimpleNamespace(vel=jp.zeros((5, 3)), ang=jp.zeros((5, 3)))
+        assert float(env._reward_ang_vel_xy(xd_zero)) == 0.0
+        xd_nonzero = SimpleNamespace(
+            vel=jp.zeros((5, 3)),
+            ang=jp.zeros((5, 3)).at[1, 0].set(1.0),
+        )
+        assert float(env._reward_ang_vel_xy(xd_nonzero)) > 0.0
+
+
+class TestRewardOrientation:
+    def test_reward_orientation(self):
+        env = _build_env()
+        env._base_body_id = 1
+        x_upright = SimpleNamespace(
+            pos=jp.zeros((5, 3)),
+            rot=jp.array([[1.0, 0.0, 0.0, 0.0]] * 5),
+        )
+        assert float(env._reward_orientation(x_upright)) == pytest.approx(0.0, abs=1e-5)
+        # Tilted 90 degrees around x-axis
+        import math as pymath
+        a = pymath.pi / 4
+        q = jp.array([pymath.cos(a / 2), pymath.sin(a / 2), 0.0, 0.0])
+        x_tilted = SimpleNamespace(
+            pos=jp.zeros((5, 3)),
+            rot=jp.tile(q, (5, 1)),
+        )
+        assert float(env._reward_orientation(x_tilted)) > 0.0
+
+
+class TestRewardTorques:
+    def test_reward_torques(self):
+        env = _build_env()
+        assert float(env._reward_torques(jp.zeros(15))) == 0.0
+        assert float(env._reward_torques(jp.ones(15))) > 0.0
+
+
+class TestRewardActionRate:
+    def test_reward_action_rate(self):
+        env = _build_env()
+        same = jp.ones(9)
+        assert float(env._reward_action_rate(same, same)) == 0.0
+        diff = jp.zeros(9)
+        assert float(env._reward_action_rate(same, diff)) > 0.0
+
+
+class TestRewardJointAcc:
+    def test_reward_joint_acc(self):
+        env = _build_env()
+        v = jp.ones(9)
+        assert float(env._reward_joint_acc(v, v)) == 0.0
+        assert float(env._reward_joint_acc(v, jp.zeros(9))) > 0.0
+
+
+class TestRewardTrackingLinVel:
+    def test_reward_tracking_lin_vel(self):
+        env = _build_env()
+        env._base_body_id = 1
+        cmd = jp.array([0.3, 0.0, 0.0])
+        # Identity rotation, velocity matching command
+        x = SimpleNamespace(
+            pos=jp.zeros((5, 3)),
+            rot=jp.array([[1.0, 0.0, 0.0, 0.0]] * 5),
+        )
+        xd_match = SimpleNamespace(
+            vel=jp.zeros((5, 3)).at[1, :2].set(jp.array([0.3, 0.0])),
+            ang=jp.zeros((5, 3)),
+        )
+        r_match = float(env._reward_tracking_lin_vel(cmd, x, xd_match))
+        assert r_match == pytest.approx(1.0, abs=0.01)
+        xd_off = SimpleNamespace(
+            vel=jp.zeros((5, 3)).at[1, :2].set(jp.array([1.0, 1.0])),
+            ang=jp.zeros((5, 3)),
+        )
+        r_off = float(env._reward_tracking_lin_vel(cmd, x, xd_off))
+        assert r_off < r_match
+
+
+class TestRewardTrackingAngVel:
+    def test_reward_tracking_ang_vel(self):
+        env = _build_env()
+        env._base_body_id = 1
+        cmd = jp.array([0.0, 0.0, 0.3])
+        x = SimpleNamespace(
+            pos=jp.zeros((5, 3)),
+            rot=jp.array([[1.0, 0.0, 0.0, 0.0]] * 5),
+        )
+        xd_match = SimpleNamespace(
+            vel=jp.zeros((5, 3)),
+            ang=jp.zeros((5, 3)).at[1, 2].set(0.3),
+        )
+        r = float(env._reward_tracking_ang_vel(cmd, x, xd_match))
+        assert r == pytest.approx(1.0, abs=0.01)
+
+
+class TestRewardFeetAirTime:
+    def test_reward_feet_air_time(self):
+        env = _build_env()
+        air_time = jp.array([0.2, 0.1, 0.3, 0.0])
+        first_contact = jp.array([True, False, True, False])
+        cmd = jp.array([0.3, 0.0, 0.0])  # non-zero so multiplier > 0
+        r = env._reward_feet_air_time(air_time, first_contact, cmd)
+        assert isinstance(float(r), float)
+
+
+class TestRewardStandStill:
+    def test_reward_stand_still(self):
+        env = _build_env()
+        cmd_zero = jp.array([0.0, 0.0, 0.0])
+        joint_vel = jp.ones(9)
+        r = float(env._reward_stand_still(cmd_zero, joint_vel))
+        assert r > 0.0  # penalizes motion when command is zero
+
+
+class TestRewardFootSlip:
+    def test_reward_foot_slip(self):
+        env = _build_env()
+        env._lower_leg_body_id = np.array([])
+        ps = _make_pipeline_state()
+        contact = jp.ones(4, dtype=bool)
+        assert float(env._reward_foot_slip(ps, contact)) == 0.0
+
+
+class TestRewardTermination:
+    def test_reward_termination(self):
+        env = _build_env()
+        assert float(env._reward_termination(jp.bool_(True), jp.int32(10))) == 1.0
+        assert float(env._reward_termination(jp.bool_(True), jp.int32(600))) == 0.0
+
+
+class TestRewardEnergy:
+    def test_reward_energy(self):
+        env = _build_env()
+        env._qd_joint_start = 6
+        assert float(env._reward_energy(jp.zeros(9), jp.zeros(15))) == 0.0
+        assert float(env._reward_energy(jp.ones(9), jp.ones(15))) > 0.0

--- a/tests/test_domain_randomization.py
+++ b/tests/test_domain_randomization.py
@@ -1,0 +1,57 @@
+"""Tests for locomotion/domain_randomization.py (1 test)."""
+
+import jax
+import jax.numpy as jp
+import pytest
+
+
+class _FakeSys:
+    """Minimal stand-in for brax.base.System with JAX pytree + tree_replace."""
+
+    def __init__(self, geom_friction, actuator_gainprm, actuator_biasprm):
+        self.geom_friction = geom_friction
+        self.actuator_gainprm = actuator_gainprm
+        self.actuator_biasprm = actuator_biasprm
+
+    def tree_replace(self, replacements):
+        new = _FakeSys(self.geom_friction, self.actuator_gainprm, self.actuator_biasprm)
+        for k, v in replacements.items():
+            setattr(new, k, v)
+        return new
+
+
+# Register as JAX pytree so jax.tree_util.tree_map works
+jax.tree_util.register_pytree_node(
+    _FakeSys,
+    lambda s: ((s.geom_friction, s.actuator_gainprm, s.actuator_biasprm), None),
+    lambda _, xs: _FakeSys(*xs),
+)
+
+
+def test_domain_randomize():
+    """domain_randomize returns (sys, in_axes) with correctly shaped randomized fields."""
+    from domain_randomization import domain_randomize
+
+    n_geoms = 4
+    n_actuators = 9
+
+    sys = _FakeSys(
+        geom_friction=jp.ones((n_geoms, 3)),
+        actuator_gainprm=jp.zeros((n_actuators, 10)),
+        actuator_biasprm=jp.zeros((n_actuators, 10)),
+    )
+
+    batch = 4
+    rng = jax.random.split(jax.random.PRNGKey(0), batch)
+
+    new_sys, in_axes = domain_randomize(sys, rng)
+
+    # Shapes should have batch dimension prepended
+    assert new_sys.geom_friction.shape == (batch, n_geoms, 3)
+    assert new_sys.actuator_gainprm.shape == (batch, n_actuators, 10)
+    assert new_sys.actuator_biasprm.shape == (batch, n_actuators, 10)
+
+    # in_axes should mark randomized fields with 0, others with None
+    assert in_axes.geom_friction == 0
+    assert in_axes.actuator_gainprm == 0
+    assert in_axes.actuator_biasprm == 0

--- a/tests/test_onnx_export.py
+++ b/tests/test_onnx_export.py
@@ -1,0 +1,26 @@
+"""Tests for locomotion/onnx_export.py (1 test)."""
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+import pytest
+
+
+def test_export_policy_to_onnx(tmp_path, fake_policy_params):
+    """Exported ONNX model is valid and produces correct-shape bounded output."""
+    from onnx_export import export_policy_to_onnx
+
+    out = tmp_path / "policy.onnx"
+    export_policy_to_onnx(fake_policy_params, str(out))
+
+    # File exists and is a valid ONNX model
+    assert out.exists()
+    model = onnx.load(str(out))
+    onnx.checker.check_model(model)
+
+    # Inference produces [1, 9] output in [-1, 1]
+    sess = ort.InferenceSession(str(out))
+    obs = np.random.randn(1, 510).astype(np.float32)
+    (action,) = sess.run(None, {"observation": obs})
+    assert action.shape == (1, 9)
+    assert np.all(action >= -1.0) and np.all(action <= 1.0)

--- a/tests/test_teleop_locomotion.py
+++ b/tests/test_teleop_locomotion.py
@@ -1,0 +1,188 @@
+"""Tests for teleop_locomotion.py (7 tests)."""
+
+from unittest.mock import MagicMock, patch, call
+from types import SimpleNamespace
+import sys
+
+import numpy as np
+import pytest
+
+import teleop_locomotion  # conftest pre-imports mujoco so this is safe
+
+
+# ---------------------------------------------------------------------------
+# _TerminalInput tests
+# ---------------------------------------------------------------------------
+
+class TestTerminalInputInit:
+    def test_terminal_input_init(self):
+        from teleop_locomotion import _TerminalInput
+        ti = _TerminalInput()
+        assert ti.enabled is False
+        assert ti._fd is None
+        assert ti._old_term is None
+
+
+class TestTerminalInputEnter:
+    def test_enter(self):
+        from teleop_locomotion import _TerminalInput
+
+        ti = _TerminalInput()
+        fake_fd = 0
+        fake_old = [0] * 7  # termios attr list
+
+        with patch.object(sys, "stdin") as mock_stdin, \
+             patch("teleop_locomotion.termios.tcgetattr", return_value=fake_old), \
+             patch("teleop_locomotion.tty.setcbreak") as mock_cbreak:
+
+            mock_stdin.isatty.return_value = True
+            mock_stdin.fileno.return_value = fake_fd
+
+            result = ti.__enter__()
+
+        assert result is ti
+        assert ti.enabled is True
+        mock_cbreak.assert_called_once_with(fake_fd)
+
+
+class TestTerminalInputExit:
+    def test_exit(self):
+        from teleop_locomotion import _TerminalInput
+
+        ti = _TerminalInput()
+        ti.enabled = True
+        ti._fd = 0
+        ti._old_term = [0] * 7
+
+        with patch("teleop_locomotion.termios.tcsetattr") as mock_tc:
+            ti.__exit__(None, None, None)
+
+        mock_tc.assert_called_once()
+        assert ti.enabled is False
+
+
+class TestReadArrowTail:
+    def test_read_arrow_tail(self):
+        from teleop_locomotion import _TerminalInput
+
+        ti = _TerminalInput()
+        ti.enabled = True
+
+        # Simulate reading "[D" (left arrow tail)
+        read_calls = iter(["[", "D"])
+        with patch.object(sys, "stdin") as mock_stdin, \
+             patch("teleop_locomotion.select.select") as mock_select:
+
+            mock_stdin.read = lambda n: next(read_calls)
+            # Both select calls return readable
+            mock_select.return_value = ([mock_stdin], [], [])
+
+            result = ti._read_arrow_tail()
+
+        assert result == "[D"
+
+
+class TestReadKeys:
+    def test_read_keys(self):
+        from teleop_locomotion import _TerminalInput
+
+        # Disabled returns empty
+        ti = _TerminalInput()
+        assert ti.read_keys() == []
+
+        # Enabled returns chars
+        ti.enabled = True
+        chars = iter(["w", ""])
+        select_results = iter([
+            ([True], [], []),  # first call: readable
+            ([], [], []),       # second call: nothing
+        ])
+        with patch("teleop_locomotion.select.select", side_effect=select_results), \
+             patch.object(sys, "stdin") as mock_stdin:
+            mock_stdin.read = lambda n: next(chars)
+            keys = ti.read_keys()
+
+        assert keys == ["w"]
+
+
+# ---------------------------------------------------------------------------
+# build_obs test
+# ---------------------------------------------------------------------------
+
+class TestBuildObs:
+    def test_build_obs(self):
+        from teleop_locomotion import build_obs, OBS_SIZE, TOTAL_OBS, DEFAULT_POSE, NUM_ACTUATORS
+
+        data = SimpleNamespace(
+            xmat=np.tile(np.eye(3).flatten(), (5, 1)),  # identity rotation per body
+            cvel=np.zeros((5, 6)),                       # (rot, lin) per body
+            qpos=np.zeros(16, dtype=np.float64),
+            qvel=np.zeros(15, dtype=np.float64),
+        )
+        # Set joint positions to default pose
+        data.qpos[7:16] = DEFAULT_POSE
+
+        base_body_id = 1
+        command = np.array([0.1, 0.0, 0.0], dtype=np.float32)
+        last_action = np.zeros(NUM_ACTUATORS, dtype=np.float32)
+        obs_history = np.zeros(TOTAL_OBS, dtype=np.float32)
+
+        obs = build_obs(data, base_body_id, command, last_action, obs_history)
+        assert obs.shape == (TOTAL_OBS,)
+
+        # First OBS_SIZE elements should be set (not all zero due to gravity)
+        assert not np.allclose(obs[:OBS_SIZE], 0.0)
+
+        # Second call should stack (history rolls)
+        obs2 = build_obs(data, base_body_id, command, last_action, obs)
+        assert not np.allclose(obs2[OBS_SIZE:2 * OBS_SIZE], 0.0)
+
+        # All values within clip bounds
+        assert np.all(obs2 >= -100.0) and np.all(obs2 <= 100.0)
+
+
+# ---------------------------------------------------------------------------
+# main() test
+# ---------------------------------------------------------------------------
+
+class TestMain:
+    def test_main(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", [
+            "teleop_locomotion.py",
+            "--no-policy",
+            "--xml-path", "dummy.xml",
+        ])
+
+        mock_model = MagicMock()
+        mock_model.opt.timestep = 0.004
+        mock_model.dof_damping = np.zeros(15)
+        mock_data = MagicMock()
+        mock_data.qpos = np.zeros(16, dtype=np.float64)
+        mock_data.qvel = np.zeros(15, dtype=np.float64)
+        mock_data.xmat = np.tile(np.eye(3).flatten(), (5, 1))
+        mock_data.cvel = np.zeros((5, 6))
+        mock_data.ctrl = np.zeros(9)
+
+        mock_viewer_ctx = MagicMock()
+        mock_viewer_ctx.is_running.return_value = False
+
+        mock_from_xml = MagicMock(return_value=mock_model)
+        mock_term_inst = MagicMock()
+        mock_term_inst.read_keys.return_value = []
+
+        with patch.object(teleop_locomotion.mujoco.MjModel, "from_xml_path", mock_from_xml), \
+             patch.object(teleop_locomotion.mujoco, "MjData", return_value=mock_data), \
+             patch.object(teleop_locomotion.mujoco, "mj_name2id", return_value=1), \
+             patch.object(teleop_locomotion.mujoco, "mj_resetData"), \
+             patch.object(teleop_locomotion.mujoco, "mj_forward"), \
+             patch.object(teleop_locomotion.mujoco, "viewer") as mock_viewer_mod, \
+             patch.object(teleop_locomotion, "_TerminalInput") as mock_term_cls:
+
+            mock_viewer_mod.launch_passive.return_value.__enter__ = MagicMock(return_value=mock_viewer_ctx)
+            mock_viewer_mod.launch_passive.return_value.__exit__ = MagicMock(return_value=False)
+            mock_term_cls.return_value.__enter__ = MagicMock(return_value=mock_term_inst)
+            mock_term_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+            teleop_locomotion.main()
+
+        mock_from_xml.assert_called_once_with("dummy.xml")

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -11,7 +11,9 @@ import train as train_module
 
 def test_main(monkeypatch, fake_policy_params):
     """main() registers env, calls ppo.train with test config, and exports ONNX."""
-    monkeypatch.setattr(sys, "argv", ["train.py", "--test", "--output", "/tmp/test_policy.onnx"])
+    monkeypatch.setattr(sys, "argv", [
+        "train.py", "--test", "--no-video", "--output", "/tmp/test_policy.onnx",
+    ])
 
     mock_ppo_train = MagicMock(return_value=(MagicMock(), fake_policy_params, {}))
     mock_export = MagicMock()

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,31 @@
+"""Tests for locomotion/train.py (1 test)."""
+
+from unittest.mock import MagicMock, patch
+import sys
+
+import pytest
+
+# Import train module (conftest pre-imports mujoco so MUJOCO_GL=egl is harmless)
+import train as train_module
+
+
+def test_main(monkeypatch, fake_policy_params):
+    """main() registers env, calls ppo.train with test config, and exports ONNX."""
+    monkeypatch.setattr(sys, "argv", ["train.py", "--test", "--output", "/tmp/test_policy.onnx"])
+
+    mock_ppo_train = MagicMock(return_value=(MagicMock(), fake_policy_params, {}))
+    mock_export = MagicMock()
+    mock_register = MagicMock()
+    mock_get_env = MagicMock(return_value=MagicMock())
+
+    with patch.object(train_module.ppo, "train", mock_ppo_train), \
+         patch.object(train_module, "export_policy_to_onnx", mock_export), \
+         patch.object(train_module.envs, "register_environment", mock_register), \
+         patch.object(train_module.envs, "get_environment", mock_get_env), \
+         patch("os.makedirs"):
+
+        train_module.main()
+
+    mock_register.assert_called_once_with("bittle", train_module.BittleEnv)
+    mock_ppo_train.assert_called_once()
+    mock_export.assert_called_once_with(fake_policy_params, "/tmp/test_policy.onnx")


### PR DESCRIPTION
## Summary
- Set up pytest infrastructure: `conftest.py` with JAX CPU mode, sys.path setup, mujoco pre-import, and `fake_policy_params` fixture
- Added `pytest>=8.0` and `pytest-mock>=3.12` to dev deps in `pyproject.toml` with `[tool.pytest.ini_options]`
- Created `.vscode/settings.json` for VS Code Test Explorer discovery
- Wrote 29 tests (1 per function) covering all 5 core Python modules:
  - `test_bittle_env.py` (19): config, env lifecycle, observations, all 13 reward functions
  - `test_domain_randomization.py` (1): randomized sys fields and vmap axes
  - `test_onnx_export.py` (1): full export → load → inference pipeline
  - `test_train.py` (1): main() with mocked PPO training
  - `test_teleop_locomotion.py` (7): terminal input, observation builder, main loop

## Test plan
- [x] All 29 tests pass (`pytest tests/ -v`)
- [x] Total runtime ~7.5s for the 29 new tests, no test exceeds 10s
- [x] No GPU or physics sim required (all heavy deps mocked)
- [ ] VS Code: Command Palette > "Python: Discover Tests" shows all 29

🤖 Generated with [Claude Code](https://claude.com/claude-code)